### PR TITLE
Implement Boolean/checkbox type to display correctly

### DIFF
--- a/generators/entity-client/templates/ionic/src/pages/entities/_entity-dialog.html
+++ b/generators/entity-client/templates/ionic/src/pages/entities/_entity-dialog.html
@@ -107,6 +107,9 @@ _%>
                 <%_ } else if (fieldType === 'LocalDate' || ['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
                 <ion-label><%= fieldNameHumanized %></ion-label>
                 <ion-datetime displayFormat="MM/DD/YYYY" formControlName="<%= fieldName %>" id="field_<%= fieldName %>"></ion-datetime>
+                <%_ } else if (fieldType === 'Boolean') { _%>
+                <ion-label><%= fieldNameHumanized %></ion-label>
+                <ion-checkbox formControlName="<%= fieldName %>"></ion-checkbox>
                 <%_ } else if (fieldTypeBlobContent === 'text') { _%>
                 <ion-textarea placeholder="<%= fieldNameHumanized %>" formControlName="<%= fieldName %>" id="field_<%= fieldName %>"></ion-textarea>
                 <%_ } else { _%>

--- a/generators/entity-client/templates/ionic/src/pages/entities/_entity-dialog.ts
+++ b/generators/entity-client/templates/ionic/src/pages/entities/_entity-dialog.ts
@@ -114,8 +114,12 @@ export class <%= entityAngularName %>DialogPage {
             const fieldNameCapitalized = fields[idx].fieldNameCapitalized;
             const fieldNameHumanized = fields[idx].fieldNameHumanized;
             const fieldType = fields[idx].fieldType;
-        _%>
+        _%> 
+            <%_ if (fieldType === 'Boolean') { _%>
+            <%= fieldName %>: [params.get('item') ? this.<%= entityInstance %>.<%= fieldName %> : 'false', <% if (fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.indexOf('required') !== -1) { %> Validators.required<% } %>],
+            <%_ } else { _%>
             <%= fieldName %>: [params.get('item') ? this.<%= entityInstance %>.<%= fieldName %> : '', <% if (fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.indexOf('required') !== -1) { %> Validators.required<% } %>],
+            <%_ } _%>
             <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fields[idx].fieldTypeBlobContent !== 'text') { _%>
             <%= fieldName %>ContentType: [params.get('item') ? this.<%= entityInstance %>.<%= fieldName %>ContentType : ''],
             <%_ } _%>


### PR DESCRIPTION
As per, [https://ionicframework.com/docs/api/components/input/Input/](https://ionicframework.com/docs/api/components/input/Input/), checkbox can not be implemented with `input type='checkbox'` in ionic.

- Added checkbox support with `ion-checkbox`

- default value for boolean from model constructor does not reflect in UI, thus I added a default `false` during form initialization.