### PR TITLE
Revert to JHipster 6.7.0

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -173,8 +173,8 @@ module.exports = class extends BaseGenerator {
     packageJSON.homepage = 'https://www.jhipster.tech';
     packageJSON.description = 'A hipster Ionic project, made with 💙 by @oktadev!';
     packageJSON.devDependencies['generator-jhipster-ionic'] = packagejs.version;
-    // upgrade to JHipster 6.8.0
-    packageJSON.devDependencies['generator-jhipster'] = '6.8.0';
+    // force JHipster 6.7.0 to fix https://github.com/jhipster/generator-jhipster/issues/11501
+    packageJSON.devDependencies['generator-jhipster'] = '6.7.0';
     // fix ng-bootstrap issue https://github.com/oktadeveloper/generator-jhipster-ionic/issues/252
     // remove when Ionic 5 supports Angular 9
     packageJSON.dependencies['@ng-bootstrap/ng-bootstrap'] = '5.3.0';


### PR DESCRIPTION
Revert to 6.7.0 since [the PR for 6.8.0](https://github.com/oktadeveloper/generator-jhipster-ionic/pull/274) failed once it arrived on master.

https://travis-ci.org/github/oktadeveloper/generator-jhipster-ionic/builds/666511141